### PR TITLE
Add member to group

### DIFF
--- a/NutriRank.xcodeproj/project.pbxproj
+++ b/NutriRank.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		B9B319022AD6C4B1003F6E11 /* FetchGroupByIdUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B319012AD6C4B1003F6E11 /* FetchGroupByIdUseCase.swift */; };
 		B9B319042AD6D93A003F6E11 /* AddMemberToGroupUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B319032AD6D93A003F6E11 /* AddMemberToGroupUseCase.swift */; };
 		B9DDA8522AE0005E002BA0B6 /* FeedPostViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DDA8512AE0005E002BA0B6 /* FeedPostViewFactory.swift */; };
+		B9DDA8542AE023B8002BA0B6 /* FetchGroupByMemberUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DDA8532AE023B8002BA0B6 /* FetchGroupByMemberUseCase.swift */; };
 		B9E0D1912ADD6EEF001661DD /* Mixpanel in Frameworks */ = {isa = PBXBuildFile; productRef = B9E0D1902ADD6EEF001661DD /* Mixpanel */; };
 		B9EF0C1E2ACEEB7900CA8CF6 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9EF0C1B2ACEEB7900CA8CF6 /* EmptyStateView.swift */; };
 		B9EF0C1F2ACEEB7900CA8CF6 /* GroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9EF0C1C2ACEEB7900CA8CF6 /* GroupView.swift */; };
@@ -137,6 +138,7 @@
 		B9B319012AD6C4B1003F6E11 /* FetchGroupByIdUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchGroupByIdUseCase.swift; sourceTree = "<group>"; };
 		B9B319032AD6D93A003F6E11 /* AddMemberToGroupUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMemberToGroupUseCase.swift; sourceTree = "<group>"; };
 		B9DDA8512AE0005E002BA0B6 /* FeedPostViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedPostViewFactory.swift; sourceTree = "<group>"; };
+		B9DDA8532AE023B8002BA0B6 /* FetchGroupByMemberUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchGroupByMemberUseCase.swift; sourceTree = "<group>"; };
 		B9EF0C1B2ACEEB7900CA8CF6 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		B9EF0C1C2ACEEB7900CA8CF6 /* GroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupView.swift; sourceTree = "<group>"; };
 		B9EF0C1D2ACEEB7900CA8CF6 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 				B98EEEC22ACC5C94001B1DD3 /* DeleteChallengeGroupUseCase.swift */,
 				B98EEEC32ACC5C94001B1DD3 /* FetchGroupsUseCase.swift */,
 				B9B319012AD6C4B1003F6E11 /* FetchGroupByIdUseCase.swift */,
+				B9DDA8532AE023B8002BA0B6 /* FetchGroupByMemberUseCase.swift */,
 			);
 			path = Group;
 			sourceTree = "<group>";
@@ -610,6 +613,7 @@
 				B98EEED42ACC5F37001B1DD3 /* DeleteChallengeGroupUseCase.swift in Sources */,
 				B98EEED12ACC5F2F001B1DD3 /* GetChallengePostsByOwnerUseCase.swift in Sources */,
 				B98EEECC2ACC5F1A001B1DD3 /* ChallengeGroupUIModel.swift in Sources */,
+				B9DDA8542AE023B8002BA0B6 /* FetchGroupByMemberUseCase.swift in Sources */,
 				363300F32ACF4EE70083D5B8 /* RankingView.swift in Sources */,
 				B98EEED52ACC5F3A001B1DD3 /* FetchGroupsUseCase.swift in Sources */,
 				4B5478BE2AD42D510029AF65 /* FeedPostView.swift in Sources */,

--- a/NutriRank.xcodeproj/xcuserdata/paulohenriquegomesdasilva.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/NutriRank.xcodeproj/xcuserdata/paulohenriquegomesdasilva.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "D8B03367-3EC6-45FC-A3C3-4DAA1B78275C"
+   type = "1"
+   version = "2.0">
+</Bucket>

--- a/NutriRank/Data/NutriRankClient.swift
+++ b/NutriRank/Data/NutriRankClient.swift
@@ -49,8 +49,10 @@ public class NutriRankNuvemClient: ChallengeGroupRepositoryProtocol {
 
     public func fetchGroupByMember(member: Member) async -> Result<ChallengeGroup, Error> {
         do {
-            let result = try await ChallengeGroup.query(on: self.database).all()
-            return .success(ChallengeGroup())
+            let reference = CKRecord.Reference(recordID: .init(recordName: member.id), action: .none)
+            guard let result = try await ChallengeGroup.query(on: self.database).filter(.predicate(format: "members contains %@", reference)).first() else { return .failure(SaveErrors.guardError)}
+            print(result)
+            return .success(result)
         } catch {
             return .failure(error)
         }

--- a/NutriRank/Domain/Repositories/ChallengeGroupRepository.swift
+++ b/NutriRank/Domain/Repositories/ChallengeGroupRepository.swift
@@ -58,10 +58,10 @@ public class DefaultChallengeGroupRepository: ChallengeGroupRepositoryProtocol {
     }
 
     public func fetchGroupByMember(member: Member) async -> Result<ChallengeGroup, Error> {
-        let result = await data.fetchChallengeGroups()
+        let result = await data.fetchGroupByMember(member: member)
         switch result {
-        case .success(let groups):
-            return .success(ChallengeGroup())
+        case .success(let group):
+            return .success(group)
         case .failure(let error):
             return .failure(error)
         }
@@ -76,6 +76,8 @@ public class DefaultChallengeGroupRepository: ChallengeGroupRepositoryProtocol {
             return .failure(error)
         }
     }
+
+
 }
 
 

--- a/NutriRank/Domain/UseCases/Group/FetchGroupByMemberUseCase.swift
+++ b/NutriRank/Domain/UseCases/Group/FetchGroupByMemberUseCase.swift
@@ -1,0 +1,31 @@
+//
+//  FetchGroupByMember.swift
+//  NutriRank
+//
+//  Created by Paulo Henrique Gomes da Silva on 18/10/23.
+//
+
+import Foundation
+
+public protocol FetchGroupByMemberUseCaseProtocol {
+    func execute(requestValue: Member) async -> Result<ChallengeGroup, Error>
+}
+
+public final class DefaultFetchGroupByMemberUseCase: FetchGroupByMemberUseCaseProtocol {
+
+    let repository: ChallengeGroupRepositoryProtocol
+
+    public init(repository: ChallengeGroupRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    public func execute(requestValue: Member) async -> Result<ChallengeGroup, Error> {
+        let result = await repository.fetchGroupByMember(member: requestValue)
+        switch result {
+        case .success(let group):
+            return .success(group)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+}

--- a/NutriRank/Factory/ChallengeGroupFactory.swift
+++ b/NutriRank/Factory/ChallengeGroupFactory.swift
@@ -20,7 +20,6 @@ struct ChallengeGroupFactory {
         let createUseCase = DefaultCreateChallengeGroupUseCase(challengeGroupRepository: repository)
         let memberRepository = DefaultChallengeMemberRepository(data: memberData)
 
-
         let fetchUseCase = DefaultFetchGroupsUseCase(challengeGroupRepository: repository)
         let deleteUseCase = DefaultDeleteChallengeGroupUseCase(challengeGroupRepository: repository)
         let postUseCase = DefaultCreateChallengePostUseCase(repository: postRepository)
@@ -30,8 +29,9 @@ struct ChallengeGroupFactory {
         let addMemberUseCase = DefaultAddMemberToGroupUseCase(repository: memberRepository)
         let fetchGroupById = DefaultFetchGroupByIdUsecase(repository: repository)
         let fetchPostsUseCase = DefaultFetchChallengePostsUseCase(repository: postRepository)
+        let fetchGroupByMember = DefaultFetchGroupByMemberUseCase(repository: repository)
 
-        let viewmodel = FeedGroupViewModel(createUseCase: createUseCase, createPostUseCase: postUseCase, fetchUseCase: fetchUseCase, deleteUseCase: deleteUseCase, createMemberUseCase: createMemberUseCase, updateMemberUseCase: updateMemberUseCase, fetchMemberUseCase: fetchMemberUseCase, fetchGroupByIDUseCase: fetchGroupById, addMemberUseCase: addMemberUseCase, fetchPostsByGroup: fetchPostsUseCase)
+        let viewmodel = FeedGroupViewModel(createUseCase: createUseCase, createPostUseCase: postUseCase, fetchUseCase: fetchUseCase, deleteUseCase: deleteUseCase, createMemberUseCase: createMemberUseCase, updateMemberUseCase: updateMemberUseCase, fetchMemberUseCase: fetchMemberUseCase, fetchGroupByIDUseCase: fetchGroupById, addMemberUseCase: addMemberUseCase, fetchPostsByGroup: fetchPostsUseCase, fetchGroupByMember: fetchGroupByMember)
 
         return EmptyStateView(viewmodel: viewmodel)
     }

--- a/NutriRank/Factory/FeedPostViewFactory.swift
+++ b/NutriRank/Factory/FeedPostViewFactory.swift
@@ -29,8 +29,9 @@ struct FeedPostViewFactory {
         let addMemberUseCase = DefaultAddMemberToGroupUseCase(repository: memberRepository)
         let fetchGroupByIDUseCase = DefaultFetchGroupByIdUsecase(repository: repository)
         let fetchPostsByGroupUseCase = DefaultFetchChallengePostsUseCase(repository: postRepository)
+        let fetchGroupByMember = DefaultFetchGroupByMemberUseCase(repository: repository)
 
-        let viewmodel = FeedGroupViewModel(createUseCase: createUseCase, createPostUseCase: postUseCase, fetchUseCase: fetchUseCase, deleteUseCase: deleteUseCase, createMemberUseCase: createMemberUseCase, updateMemberUseCase: updateMemberUseCase, fetchMemberUseCase: fetchMemberUseCase, fetchGroupByIDUseCase: fetchGroupByIDUseCase, addMemberUseCase: addMemberUseCase, fetchPostsByGroup: fetchPostsByGroupUseCase)
+        let viewmodel = FeedGroupViewModel(createUseCase: createUseCase, createPostUseCase: postUseCase, fetchUseCase: fetchUseCase, deleteUseCase: deleteUseCase, createMemberUseCase: createMemberUseCase, updateMemberUseCase: updateMemberUseCase, fetchMemberUseCase: fetchMemberUseCase, fetchGroupByIDUseCase: fetchGroupByIDUseCase, addMemberUseCase: addMemberUseCase, fetchPostsByGroup: fetchPostsByGroupUseCase, fetchGroupByMember: fetchGroupByMember)
 
         return FeedPostView(viewmodel: viewmodel)
     }

--- a/NutriRank/Factory/FirstTimeUsingAppFactory.swift
+++ b/NutriRank/Factory/FirstTimeUsingAppFactory.swift
@@ -27,10 +27,11 @@ struct FirstTimeUsingAppFactory {
         let updateMemberUseCase = DefaultUpdateChallengeMemberUseCase(challengeMemberRepository: memberRepository)
         let fetchMemberUseCase = DefaultFetchChallengeMember(challengeMemberRepository: memberRepository)
         let addMemberUseCase = DefaultAddMemberToGroupUseCase(repository: memberRepository)
-        let fetchGroupByIDUseCase = DefaultFetchGroupByIdUsecase(repository: repository)
-        let fetchPostsByGroupUseCase = DefaultFetchChallengePostsUseCase(repository: postRepository)
+        let fetchGroupById = DefaultFetchGroupByIdUsecase(repository: repository)
+        let fetchPostsUseCase = DefaultFetchChallengePostsUseCase(repository: postRepository)
+        let fetchGroupByMember = DefaultFetchGroupByMemberUseCase(repository: repository)
 
-        let viewmodel = FeedGroupViewModel(createUseCase: createUseCase, createPostUseCase: postUseCase, fetchUseCase: fetchUseCase, deleteUseCase: deleteUseCase, createMemberUseCase: createMemberUseCase, updateMemberUseCase: updateMemberUseCase, fetchMemberUseCase: fetchMemberUseCase, fetchGroupByIDUseCase: fetchGroupByIDUseCase, addMemberUseCase: addMemberUseCase, fetchPostsByGroup: fetchPostsByGroupUseCase)
+        let viewmodel = FeedGroupViewModel(createUseCase: createUseCase, createPostUseCase: postUseCase, fetchUseCase: fetchUseCase, deleteUseCase: deleteUseCase, createMemberUseCase: createMemberUseCase, updateMemberUseCase: updateMemberUseCase, fetchMemberUseCase: fetchMemberUseCase, fetchGroupByIDUseCase: fetchGroupById, addMemberUseCase: addMemberUseCase, fetchPostsByGroup: fetchPostsUseCase, fetchGroupByMember: fetchGroupByMember)
 
         return OnboardingView(viewModel: viewmodel)
     }

--- a/NutriRank/NutriRankApp.swift
+++ b/NutriRank/NutriRankApp.swift
@@ -11,8 +11,6 @@ import SwiftUI
 struct NutriRankApp: App {
     var body: some Scene {
         WindowGroup {
-//            ChallengeGroupFactory.make()
-//            FeedPostView()
             if UserDefaults.standard.bool(forKey: "isFirstTimeUsingApp") == false {
                 FirstTimeUsingAppFactory.make()
             } else {

--- a/NutriRank/Presentation/ChallengeGroup/Views/EmptyStateView.swift
+++ b/NutriRank/Presentation/ChallengeGroup/Views/EmptyStateView.swift
@@ -21,59 +21,68 @@ public struct EmptyStateView: View {
         GeometryReader { metrics in
             NavigationStack {
                 ZStack {
-                    Color(.defaultBackground)
-                        .ignoresSafeArea()
+                    
+                        Color(.defaultBackground)
+                            .ignoresSafeArea()
 
-                    VStack (spacing: 50) {
-                        VStack {
-                            Image("logo")
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .clipShape(Rectangle())
-                                .scaledToFill()
-                                .frame(width: metrics.size.width * 0.6, height: metrics.size.height * 0.25)
-                        }
-
-                        VStack (alignment: .leading) {
-                            HStack {
-                                Image(systemName: "person.crop.circle.fill.badge.plus").font(.system(size: 18, weight: .regular))
+                        VStack (spacing: 50) {
+                            VStack {
+                                Image("logo")
+                                    .resizable()
                                     .aspectRatio(contentMode: .fit)
+                                    .clipShape(Rectangle())
                                     .scaledToFill()
-
-                                Text ("Crie um grupo")
-                                    .font(.headline)
+                                    .frame(width: metrics.size.width * 0.6, height: metrics.size.height * 0.25)
                             }
-                            Text("Você não possui grupos no momento. Crie num novo grupo e inicie novos hábitos alimentares com seus amigos!")
-                        }
-                        .padding(.horizontal, 15)
-                        .padding(.vertical, 12)
-                        .frame(maxWidth: metrics.size.width * 0.92, minHeight: metrics.size.height * 0.09)
-                        .background(.white)
-                        .cornerRadius(10)
-                        .shadow(radius: 1, x: 0, y: 1)
 
+                            VStack (alignment: .leading) {
+                                HStack {
+                                    Image(systemName: "person.crop.circle.fill.badge.plus").font(.system(size: 18, weight: .regular))
+                                        .aspectRatio(contentMode: .fit)
+                                        .scaledToFill()
 
-                        VStack {
-
-                            NavigationLink(destination: CreateGroupView(viewmodel: viewmodel)) {
-                                HStack (alignment: .center){
-                                    Image(systemName: "person.crop.circle.fill.badge.plus")
-                                        .foregroundColor(.white)
-
-                                    Text("Criar grupo")
+                                    Text ("Crie um grupo")
                                         .font(.headline)
-
-                                        .foregroundColor(.white)
                                 }
-                                .frame(width: 150, height: 35)
+                                Text("Você não possui grupos no momento. Crie num novo grupo e inicie novos hábitos alimentares com seus amigos!")
                             }
-                            .background(Color("FirstPlaceRanking"))
+                            .padding(.horizontal, 15)
+                            .padding(.vertical, 12)
+                            .frame(maxWidth: metrics.size.width * 0.92, minHeight: metrics.size.height * 0.09)
+                            .background(.white)
                             .cornerRadius(10)
-                            .buttonStyle(.bordered)
+                            .shadow(radius: 1, x: 0, y: 1)
+
+
+                            VStack {
+
+                                NavigationLink(destination: CreateGroupView(viewmodel: viewmodel)) {
+                                    HStack (alignment: .center){
+                                        Image(systemName: "person.crop.circle.fill.badge.plus")
+                                            .foregroundColor(.white)
+
+                                        Text("Criar grupo")
+                                            .font(.headline)
+
+                                            .foregroundColor(.white)
+                                    }
+                                    .frame(width: 150, height: 35)
+                                }
+                                .background(Color("FirstPlaceRanking"))
+                                .cornerRadius(10)
+                                .buttonStyle(.bordered)
+                            }
                         }
-                    }
+
+
                 }
                 .navigationBarBackButtonHidden(true)
+            }
+        }
+        .onAppear {
+            Task {
+                await viewmodel.fetchChallengeMember()
+                await viewmodel.fetchGroupByMember()
             }
         }
         .onOpenURL(perform: { url in

--- a/NutriRank/Presentation/ChallengeGroup/Views/FeedPostView.swift
+++ b/NutriRank/Presentation/ChallengeGroup/Views/FeedPostView.swift
@@ -128,6 +128,8 @@ public struct FeedPostView: View {
                                 .cancel()
                             ]
                         )
+                    }.onAppear {
+                        print(viewmodel.group.groupName)
                     }
                     .onChange(of: selectedImage) { selectedImage in
                         if selectedImage != nil {

--- a/NutriRank/Presentation/ChallengeGroup/Views/SheetCreatePostView.swift
+++ b/NutriRank/Presentation/ChallengeGroup/Views/SheetCreatePostView.swift
@@ -90,6 +90,7 @@ public struct SheetCreatePostView: View {
                                     showAlert.toggle()
                                 }
                                 await viewmodel.updateChallengeMember()
+                                dismiss()
                             }
                         }.alert("Erro ao criar post!", isPresented: $showAlert) {
                             Button("cancelar", role: .cancel){}

--- a/NutriRank/Presentation/ViewModel/FeedGroupViewModel.swift
+++ b/NutriRank/Presentation/ViewModel/FeedGroupViewModel.swift
@@ -33,6 +33,7 @@ public class FeedGroupViewModel: ObservableObject {
     let fetchGroupByIDUseCase: FetchGroupByIdUseCaseProtocol
     let addMemberUseCase: AddMemberToGroupUseCaseProtocol
     let fetchPostsByGroup: FetchChallengePostsUseCaseProtocol
+    let fetchGroupByMember: FetchGroupByMemberUseCaseProtocol
 
     public init(createUseCase: CreateChallengeGroupUseCase, 
                 createPostUseCase: CreateChallengePostUseCase,
@@ -43,7 +44,8 @@ public class FeedGroupViewModel: ObservableObject {
                 fetchMemberUseCase: FetchChallengeMemberUseCase,
                 fetchGroupByIDUseCase: FetchGroupByIdUseCaseProtocol,
                 addMemberUseCase: AddMemberToGroupUseCaseProtocol,
-                fetchPostsByGroup: FetchChallengePostsUseCaseProtocol) {
+                fetchPostsByGroup: FetchChallengePostsUseCaseProtocol,
+                fetchGroupByMember: FetchGroupByMemberUseCaseProtocol) {
         self.createUseCase = createUseCase
         self.createPostUseCase = createPostUseCase
         self.fetchUseCase = fetchUseCase
@@ -54,6 +56,7 @@ public class FeedGroupViewModel: ObservableObject {
         self.fetchGroupByIDUseCase = fetchGroupByIDUseCase
         self.addMemberUseCase = addMemberUseCase
         self.fetchPostsByGroup = fetchPostsByGroup
+        self.fetchGroupByMember = fetchGroupByMember
         group.groupName = ""
         group.description = ""
     }
@@ -100,6 +103,8 @@ public class FeedGroupViewModel: ObservableObject {
         group.startDate = startDate
         group.endDate = endDate
         group.duration = duration
+        let members = [self.member]
+        group.members = members
         let result = await createUseCase.execute(requestValue: group)
         switch result {
         case .success(let group):
@@ -237,6 +242,18 @@ public class FeedGroupViewModel: ObservableObject {
         case .success(let member):
             DispatchQueue.main.async {
                 self.member = member
+            }
+        case .failure(let error):
+            print(error)
+        }
+    }
+
+    func fetchGroupByMember() async {
+        let result = await fetchGroupByMember.execute(requestValue: self.member)
+        switch result {
+        case .success(let group):
+            DispatchQueue.main.async {
+                self.group = group
             }
         case .failure(let error):
             print(error)


### PR DESCRIPTION
# Adding member to group

Refatoração da função de criação do membro, em que não estava sendo passado a referência do membro para dentro do grupo e agora está funcional. Ademais, foram feitas algumas modificações para realizar essa tarefa no fluxo do novo caso de uso relacionado a conseguir pegar um grupo pelo membro presente nele.