### PR TITLE
Feat design adjustments

### DIFF
--- a/NutriRank/Presentation/ChallengeGroup/Views/FeedPostView.swift
+++ b/NutriRank/Presentation/ChallengeGroup/Views/FeedPostView.swift
@@ -38,7 +38,7 @@ public struct FeedPostView: View {
 
     public var body: some View {
         GeometryReader { metrics in
-            NavigationView  {
+            NavigationView {
                 ZStack {
                     Color(.defaultBackground)
                         .ignoresSafeArea()
@@ -52,9 +52,9 @@ public struct FeedPostView: View {
                                             .frame(width: 350, height: 137)
                                             .overlay(
                                                 RoundedRectangle(cornerRadius: 7)
-                                                    .stroke(Color.black, lineWidth: 1.5)
+//                                                    .stroke(Color.black, lineWidth: 1.5)
                                             )
-                                            .foregroundColor(.clear)
+                                            .foregroundColor(Color("DefaultRankingCellColor"))
                                             .shadow(radius: 1, x: 0, y: 1)
 
                                         HStack{
@@ -124,6 +124,7 @@ public struct FeedPostView: View {
 
                         NavigationLink("", destination: GroupView(viewmodel: viewmodel), isActive: $performNavigation)
                             .hidden()
+                        Spacer()
                     }
                     .actionSheet(isPresented: $isImagePickerDisplay) {
                         ActionSheet(
@@ -162,9 +163,9 @@ public struct FeedPostView: View {
                             ImagePickerView(selectedImage: self.$selectedImage, sourceType: self.sourceType)
                         }
                     }
-
                 }
-            }.navigationBarBackButtonHidden(true)
+            }
+            .navigationBarBackButtonHidden(true)
         }
     }
 }

--- a/NutriRank/Presentation/ChallengeGroup/Views/GroupView.swift
+++ b/NutriRank/Presentation/ChallengeGroup/Views/GroupView.swift
@@ -125,20 +125,17 @@ public struct GroupView: View {
                     .shadow(radius: 1, x: 0, y: 1)
 
                     VStack {
-                        Button {
-
-                        } label: {
-
+                        NavigationLink(destination: RankingView(viewmodel: viewmodel)) {
                             Image(systemName: "trophy.fill").font(.system(size: 23, weight: .regular))
                                 .foregroundColor(.white)
                             Text("Ranking")
                                 .font(.title2)
                                 .foregroundColor(.white)
-
                         }
                         .background(Color("FirstPlaceRanking"))
                         .cornerRadius(10)
                         .buttonStyle(.bordered)
+
                     }
                     .padding(.vertical,20)
 

--- a/NutriRank/Presentation/ChallengeGroup/Views/GroupView.swift
+++ b/NutriRank/Presentation/ChallengeGroup/Views/GroupView.swift
@@ -37,12 +37,12 @@ public struct GroupView: View {
 //                        Text(viewmodel.group.description)
 //                            .lineLimit(1...10)
                     }
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 12)
-                    .frame(maxWidth: metrics.size.width * 0.92, minHeight: metrics.size.height * 0.09)
-                    .background(Color("DefaultCardColor"))
-                    .cornerRadius(10)
-                    .shadow(radius: 1, x: 0, y: 1)
+//                    .padding(.horizontal, 20)
+//                    .padding(.vertical, 12)
+//                    .frame(maxWidth: metrics.size.width * 0.92, minHeight: metrics.size.height * 0.09)
+//                    .background(Color("DefaultCardColor"))
+//                    .cornerRadius(10)
+//                    .shadow(radius: 1, x: 0, y: 1)
 
                     VStack (alignment: .leading, spacing: 3){
 
@@ -110,7 +110,7 @@ public struct GroupView: View {
                                         .frame(width: 110, height: 22)
                                         .foregroundColor(.white)
                                 }
-                                .background(.blue)
+                                .background(Color("FirstPlaceRanking"))
                                 .cornerRadius(10)
                                 .buttonStyle(.bordered)
                                 Spacer()

--- a/NutriRank/Presentation/ChallengeGroup/Views/RankingView/RankingCardComponent.swift
+++ b/NutriRank/Presentation/ChallengeGroup/Views/RankingView/RankingCardComponent.swift
@@ -37,10 +37,14 @@ struct RankingCardComponent: View {
             .frame(width: 310)
             .offset(x: -16, y:-55)
 
-            Text(challengeDescription)
-                .offset(x:0,y:4)
-                .frame(width: 350, height:90)
-                .lineLimit(3)
+            HStack {
+                Text(challengeDescription)
+                Spacer()
+            }
+            .offset(x:0,y:4)
+            .frame(width: 350, height:90)
+            .lineLimit(3)
+
             Text("Duração: \(challengeSpan) dias")
                 .offset(x:-107, y:64)
 
@@ -50,6 +54,6 @@ struct RankingCardComponent: View {
 
 struct GroupHeaderComponent_Previews: PreviewProvider {
     static var previews: some View {
-        RankingCardComponent(challengeSpan: 28, challengeDescription: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas quis mauris tellus. Nulla sed venenatis enim. Sed aliquam dapibus nulla ut rhoncus. Donec et ornare nunc, non ultricies ipsum. Sed auctor est ut pretium egestas. Nunc pretium ex id tortor tempor, at efficitur elit placerat.", groupTitle: "Abcdefghijklmnopqrsaa")
+        RankingCardComponent(challengeSpan: 28, challengeDescription: "Lorem ipsum ejndiu3", groupTitle: "Abcde")
     }
 }


### PR DESCRIPTION
Ajustes de design: 
- Mudar cor do botão de copiar link para o vermelho q a gnt ta usando em todos os botões ✅
- Tirar o nome do grupo de um card e deixar ele fora sem nada na tela de informações do grupo ✅
- Fazer o card de grupo na tela de feed parecer um botão colocando uma cor de fundo nele ✅
- Fazer os elemento ficarem no topo da tela na tela de feed✅
- Ajustar a posição da descrição do grupo no card de grupo da tela do ranking view ✅

Botão ranking na tela de group view navegável para tela de ranking