### PR TITLE
Refactor: Dismissing group view

### DIFF
--- a/NutriRank.xcodeproj/xcuserdata/paulohenriquegomesdasilva.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/NutriRank.xcodeproj/xcuserdata/paulohenriquegomesdasilva.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -23,64 +23,155 @@
       <BreakpointProxy
          BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
          <BreakpointContent
-            uuid = "E75CAE40-8AB0-4866-ADDD-7071811D415D"
-            shouldBeEnabled = "No"
+            uuid = "3234A38D-EEB6-4387-BD54-BDC0DF4C23B1"
+            shouldBeEnabled = "Yes"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
-            filePath = "NutriRank/Presentation/ChallengePost/Views/FeedPostView.swift"
+            filePath = "NutriRank/Domain/Repositories/ChallengeMemberRepository.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "163"
-            endingLineNumber = "163"
-            landmarkName = "body"
-            landmarkType = "24">
+            startingLineNumber = "70"
+            endingLineNumber = "70"
+            landmarkName = "addMemberToGroup(member:group:)"
+            landmarkType = "7">
             <Locations>
                <Location
-                  uuid = "E75CAE40-8AB0-4866-ADDD-7071811D415D - c52bc89426df5883"
+                  uuid = "3234A38D-EEB6-4387-BD54-BDC0DF4C23B1 - c4063b0262ec52c9"
                   shouldBeEnabled = "Yes"
                   ignoreCount = "0"
                   continueAfterRunningActions = "No"
-                  symbolName = "closure #1 () -&gt; SwiftUI.TupleView&lt;(Swift.Optional&lt;&lt;&lt;opaque return type of SwiftUI.View.zIndex(Swift.Double) -&gt; some&gt;&gt;.0&gt;, &lt;&lt;opaque return type of SwiftUI.View.ignoresSafeArea(_: SwiftUI.SafeAreaRegions, edges: SwiftUI.Edge.Set) -&gt; some&gt;&gt;.0, &lt;&lt;opaque return type of SwiftUI.View.task(priority: Swift.TaskPriority, _: @Sendable () async -&gt; ()) -&gt; some&gt;&gt;.0)&gt; in closure #1 (SwiftUI.GeometryProxy) -&gt; &lt;&lt;opaque return type of SwiftUI.View.navigationBarBackButtonHidden(Swift.Bool) -&gt; some&gt;&gt;.0 in NutriRank.FeedPostView.body.getter : some"
+                  symbolName = "(1) suspend resume partial function for NutriRank.DefaultChallengeMemberRepository.addMemberToGroup(member: NutriRank.Member, group: NutriRank.ChallengeGroup) async -&gt; Swift.Result&lt;NutriRank.AddMemberRequestedValues, Swift.Error&gt;"
                   moduleName = "NutriRank"
                   usesParentBreakpointCondition = "Yes"
-                  urlString = "file:///Users/paulohenriquegomesdasilva/dev/NutriRank/NutriRank/Presentation/ChallengePost/Views/FeedPostView.swift"
+                  urlString = "file:///Users/paulohenriquegomesdasilva/dev/NutriRank/NutriRank/Domain/Repositories/ChallengeMemberRepository.swift"
                   startingColumnNumber = "9223372036854775807"
                   endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "161"
-                  endingLineNumber = "161"
-                  offsetFromSymbolStart = "3204">
+                  startingLineNumber = "71"
+                  endingLineNumber = "71"
+                  offsetFromSymbolStart = "1072">
                </Location>
                <Location
-                  uuid = "E75CAE40-8AB0-4866-ADDD-7071811D415D - eaf7a8c4db85f152"
+                  uuid = "3234A38D-EEB6-4387-BD54-BDC0DF4C23B1 - 1ab11cfd6c4a454a"
                   shouldBeEnabled = "Yes"
                   ignoreCount = "0"
                   continueAfterRunningActions = "No"
-                  symbolName = "closure #2 () -&gt; SwiftUI.TupleView&lt;(SwiftUI.Button&lt;SwiftUI.Text&gt;, SwiftUI.Button&lt;SwiftUI.Text&gt;)&gt; in closure #1 () -&gt; SwiftUI.TupleView&lt;(Swift.Optional&lt;&lt;&lt;opaque return type of SwiftUI.View.zIndex(Swift.Double) -&gt; some&gt;&gt;.0&gt;, &lt;&lt;opaque return type of SwiftUI.View.ignoresSafeArea(_: SwiftUI.SafeAreaRegions, edges: SwiftUI.Edge.Set) -&gt; some&gt;&gt;.0, &lt;&lt;opaque return type of SwiftUI.View.task(priority: Swift.TaskPriority, _: @Sendable () async -&gt; ()) -&gt; some&gt;&gt;.0)&gt; in closure #1 (SwiftUI.GeometryProxy) -&gt; &lt;&lt;opaque return type of SwiftUI.View.navigationBarBackButtonHidden(Swift.Bool) -&gt; some&gt;&gt;.0 in NutriRank.FeedPostView.body.getter : some"
+                  symbolName = "(2) await resume partial function for NutriRank.DefaultChallengeMemberRepository.addMemberToGroup(member: NutriRank.Member, group: NutriRank.ChallengeGroup) async -&gt; Swift.Result&lt;NutriRank.AddMemberRequestedValues, Swift.Error&gt;"
                   moduleName = "NutriRank"
                   usesParentBreakpointCondition = "Yes"
-                  urlString = "file:///Users/paulohenriquegomesdasilva/dev/NutriRank/NutriRank/Presentation/ChallengePost/Views/FeedPostView.swift"
+                  urlString = "file:///Users/paulohenriquegomesdasilva/dev/NutriRank/NutriRank/Domain/Repositories/ChallengeMemberRepository.swift"
                   startingColumnNumber = "9223372036854775807"
                   endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "161"
-                  endingLineNumber = "161"
-                  offsetFromSymbolStart = "1076">
+                  startingLineNumber = "71"
+                  endingLineNumber = "71"
+                  offsetFromSymbolStart = "44">
                </Location>
                <Location
-                  uuid = "E75CAE40-8AB0-4866-ADDD-7071811D415D - 439f450177f68a44"
+                  uuid = "3234A38D-EEB6-4387-BD54-BDC0DF4C23B1 - 159eb8b1c3d20e0b"
                   shouldBeEnabled = "Yes"
                   ignoreCount = "0"
                   continueAfterRunningActions = "No"
-                  symbolName = "closure #3 () -&gt; () in closure #1 () -&gt; SwiftUI.TupleView&lt;(Swift.Optional&lt;&lt;&lt;opaque return type of SwiftUI.View.zIndex(Swift.Double) -&gt; some&gt;&gt;.0&gt;, &lt;&lt;opaque return type of SwiftUI.View.ignoresSafeArea(_: SwiftUI.SafeAreaRegions, edges: SwiftUI.Edge.Set) -&gt; some&gt;&gt;.0, &lt;&lt;opaque return type of SwiftUI.View.task(priority: Swift.TaskPriority, _: @Sendable () async -&gt; ()) -&gt; some&gt;&gt;.0)&gt; in closure #1 (SwiftUI.GeometryProxy) -&gt; &lt;&lt;opaque return type of SwiftUI.View.navigationBarBackButtonHidden(Swift.Bool) -&gt; some&gt;&gt;.0 in NutriRank.FeedPostView.body.getter : some"
+                  symbolName = "(3) suspend resume partial function for NutriRank.DefaultChallengeMemberRepository.addMemberToGroup(member: NutriRank.Member, group: NutriRank.ChallengeGroup) async -&gt; Swift.Result&lt;NutriRank.AddMemberRequestedValues, Swift.Error&gt;"
                   moduleName = "NutriRank"
                   usesParentBreakpointCondition = "Yes"
-                  urlString = "file:///Users/paulohenriquegomesdasilva/dev/NutriRank/NutriRank/Presentation/ChallengePost/Views/FeedPostView.swift"
+                  urlString = "file:///Users/paulohenriquegomesdasilva/dev/NutriRank/NutriRank/Domain/Repositories/ChallengeMemberRepository.swift"
                   startingColumnNumber = "9223372036854775807"
                   endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "161"
-                  endingLineNumber = "161"
-                  offsetFromSymbolStart = "208">
+                  startingLineNumber = "71"
+                  endingLineNumber = "71"
+                  offsetFromSymbolStart = "136">
+               </Location>
+               <Location
+                  uuid = "3234A38D-EEB6-4387-BD54-BDC0DF4C23B1 - c4063b0262ec52c9"
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "(1) suspend resume partial function for NutriRank.DefaultChallengeMemberRepository.addMemberToGroup(member: NutriRank.Member, group: NutriRank.ChallengeGroup) async -&gt; Swift.Result&lt;NutriRank.AddMemberRequestedValues, Swift.Error&gt;"
+                  moduleName = "NutriRank"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/paulohenriquegomesdasilva/dev/NutriRank/NutriRank/Domain/Repositories/ChallengeMemberRepository.swift"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "71"
+                  endingLineNumber = "71"
+                  offsetFromSymbolStart = "1496">
+               </Location>
+               <Location
+                  uuid = "3234A38D-EEB6-4387-BD54-BDC0DF4C23B1 - 159eb8b1c3d20e0b"
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "(3) suspend resume partial function for NutriRank.DefaultChallengeMemberRepository.addMemberToGroup(member: NutriRank.Member, group: NutriRank.ChallengeGroup) async -&gt; Swift.Result&lt;NutriRank.AddMemberRequestedValues, Swift.Error&gt;"
+                  moduleName = "NutriRank"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/paulohenriquegomesdasilva/dev/NutriRank/NutriRank/Domain/Repositories/ChallengeMemberRepository.swift"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "71"
+                  endingLineNumber = "71"
+                  offsetFromSymbolStart = "128">
+               </Location>
+               <Location
+                  uuid = "3234A38D-EEB6-4387-BD54-BDC0DF4C23B1 - c4063b0262ec52ea"
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "(1) suspend resume partial function for NutriRank.DefaultChallengeMemberRepository.addMemberToGroup(member: NutriRank.Member, group: NutriRank.ChallengeGroup) async -&gt; Swift.Result&lt;NutriRank.AddMemberRequestedValues, Swift.Error&gt;"
+                  moduleName = "NutriRank"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/paulohenriquegomesdasilva/dev/NutriRank/NutriRank/Domain/Repositories/ChallengeMemberRepository.swift"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "70"
+                  endingLineNumber = "70"
+                  offsetFromSymbolStart = "1392">
+               </Location>
+               <Location
+                  uuid = "3234A38D-EEB6-4387-BD54-BDC0DF4C23B1 - 1ab11cfd6c4a4569"
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "(2) await resume partial function for NutriRank.DefaultChallengeMemberRepository.addMemberToGroup(member: NutriRank.Member, group: NutriRank.ChallengeGroup) async -&gt; Swift.Result&lt;NutriRank.AddMemberRequestedValues, Swift.Error&gt;"
+                  moduleName = "NutriRank"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/paulohenriquegomesdasilva/dev/NutriRank/NutriRank/Domain/Repositories/ChallengeMemberRepository.swift"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "70"
+                  endingLineNumber = "70"
+                  offsetFromSymbolStart = "44">
+               </Location>
+               <Location
+                  uuid = "3234A38D-EEB6-4387-BD54-BDC0DF4C23B1 - 159eb8b1c3d20e28"
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "(3) suspend resume partial function for NutriRank.DefaultChallengeMemberRepository.addMemberToGroup(member: NutriRank.Member, group: NutriRank.ChallengeGroup) async -&gt; Swift.Result&lt;NutriRank.AddMemberRequestedValues, Swift.Error&gt;"
+                  moduleName = "NutriRank"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/paulohenriquegomesdasilva/dev/NutriRank/NutriRank/Domain/Repositories/ChallengeMemberRepository.swift"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "70"
+                  endingLineNumber = "70"
+                  offsetFromSymbolStart = "128">
                </Location>
             </Locations>
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "A06824BC-4749-4890-9561-5FB809DFB90C"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "NutriRank/Presentation/ChallengeGroup/ViewModels/FeedGroupViewModel.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "137"
+            endingLineNumber = "137"
+            landmarkName = "createGroup(groupName:description:image:startDate:endDate:duration:)"
+            landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>
    </Breakpoints>

--- a/NutriRank/Data/NutriRankMemberClient.swift
+++ b/NutriRank/Data/NutriRankMemberClient.swift
@@ -17,7 +17,7 @@ public class NutriRankMemberClient: ChallengeMemberRepositoryProtocol {
     public func addMemberToGroup(member: Member, group: ChallengeGroup) async -> Result<AddMemberRequestedValues, Error> {
         do {
             var groupToSave = group
-            try await groupToSave.save(on: database)
+            try await groupToSave.save(on: self.database)
             let values = AddMemberRequestedValues(member, groupToSave)
             return .success(values)
         } catch {
@@ -27,9 +27,8 @@ public class NutriRankMemberClient: ChallengeMemberRepositoryProtocol {
     
     public func createChallengeMember(member: Member) async -> Result<Member, Error> {
         var memberToSave = member
-        let database = CKContainer(identifier: "iCloud.NutriRankContainer").publicCloudDatabase
         do {
-            try await memberToSave.save(on: database)
+            try await memberToSave.save(on: self.database)
             return .success(memberToSave)
         } catch {
             return .failure(error)
@@ -38,9 +37,8 @@ public class NutriRankMemberClient: ChallengeMemberRepositoryProtocol {
 
     public func updateChallengeMember(member: Member) async -> Result<Member, Error> {
         var memberToUpdate = member
-        let database = CKContainer(identifier: "iCloud.NutriRankContainer").publicCloudDatabase
         do {
-            try await memberToUpdate.save(on: database)
+            try await memberToUpdate.save(on: self.database)
             return .success(member)
         } catch {
             return .failure(error)
@@ -48,9 +46,8 @@ public class NutriRankMemberClient: ChallengeMemberRepositoryProtocol {
     }
 
     public func fetchChallengeMember(id: String) async -> Result<Member, Error> {
-        let database = CKContainer(identifier: "iCloud.NutriRankContainer").publicCloudDatabase
         do {
-            let fetchResult = try await Member.find(id: CKRecord.ID(recordName: id), on: database)
+            let fetchResult = try await Member.find(id: CKRecord.ID(recordName: id), on: self.database)
             return .success(fetchResult)
 
         } catch {

--- a/NutriRank/Domain/Repositories/ChallengeMemberRepository.swift
+++ b/NutriRank/Domain/Repositories/ChallengeMemberRepository.swift
@@ -56,12 +56,11 @@ public class DefaultChallengeMemberRepository: ChallengeMemberRepositoryProtocol
 
     public func addMemberToGroup(member: Member, group: ChallengeGroup) async -> Result<AddMemberRequestedValues, Error> {
         var groupToSave = group
-        var memberToSave = member
+        let memberToSave = member
         guard var members = groupToSave.members else {
             return .failure(SaveErrors.guardError)
         }
         if members.isEmpty {
-            var members = [member]
             members.append(memberToSave)
             groupToSave.members = members
         } else if !(members.contains(where: { $0.id == member.id })) {

--- a/NutriRank/Presentation/ChallengeGroup/Views/CreateGroupView.swift
+++ b/NutriRank/Presentation/ChallengeGroup/Views/CreateGroupView.swift
@@ -16,6 +16,8 @@ import Mixpanel
 
 public struct CreateGroupView: View {
 
+    @Environment(\.dismiss) var dismiss
+
     @ObservedObject var viewmodel: FeedGroupViewModel
 
     @State private var sourceType: UIImagePickerController.SourceType = .photoLibrary
@@ -168,16 +170,19 @@ public struct CreateGroupView: View {
                                 Spacer()
 
                                 Button {
-
                                     Task {
-
                                         duration = calendar.numberOfDaysBetween(start: startDate, end: endDate)
                                         if groupName == "" || description == "" || selectedImage == nil {
                                             self.showFailAlert = true
                                         } else{
                                             self.isLoading = true
-                                            if await viewmodel.createGroup(groupName: self.groupName, description: self.description, image: selectedImage, startDate: startDate, endDate: endDate, duration: duration) {
+                                            if await viewmodel.createGroup(groupName: self.groupName, 
+                                                                           description: self.description,
+                                                                           image: selectedImage, startDate: startDate,
+                                                                           endDate: endDate,
+                                                                           duration: duration) {
                                                 self.performNavigation = true
+                                                dismiss()
                                             } else {
                                                 self.isLoading = false
                                                 self.showCloudPermissionAlert = true

--- a/NutriRank/Presentation/ChallengeGroup/Views/EmptyStateView.swift
+++ b/NutriRank/Presentation/ChallengeGroup/Views/EmptyStateView.swift
@@ -109,9 +109,8 @@ public struct EmptyStateView: View {
                                                     if let uuid = UUID(uuidString: self.groupID) {
                                                         await viewmodel.fetchGroupByID(id: uuid.uuidString)
                                                         if await viewmodel.addMemberToGroup(member: self.viewmodel.member, group: self.viewmodel.group) {
-                                                            showSheet.toggle()
-                                                            if viewmodel.group.record != nil {
-                                                                await viewmodel.fetchGroupByMember()
+                                                            if await viewmodel.fetchGroupByMember() {
+                                                                showSheet.toggle()
                                                                 self.performNavigation = true
                                                             }
                                                         } else {
@@ -167,9 +166,8 @@ public struct EmptyStateView: View {
             }
             self.Isloading = true
             await viewmodel.fetchChallengeMember()
-            let result = await viewmodel.fetchGroupByMember()
-            if result {
-                self.performNavigation.toggle()
+            if await viewmodel.fetchGroupByMember() {
+                self.performNavigation = true
             } else {
                 self.Isloading = false
             }

--- a/NutriRank/Presentation/ChallengePost/Views/FeedPostView.swift
+++ b/NutriRank/Presentation/ChallengePost/Views/FeedPostView.swift
@@ -164,6 +164,7 @@ public struct FeedPostView: View {
                 .onChange(of: leavedGroup) { leavedGroup in
                     if leavedGroup {
                         dismiss()
+                        self.leavedGroup = false
                     }
                 }
                 .onChange(of: selectedImage) { selectedImage in


### PR DESCRIPTION
# Refactor

Foi feito a refatoração para que após a criação do grupo, a tela seja retirada de cena e só depois ocorra a navegação para a tela de grupo, para que assim não tenham `views` a mais na pilha que possam deixar o usuário confuso. Ademais, foi feito uma refatoração na operação de adicionar um membro ao grupo, em que ocorria uma duplicata do membro, isso não está mais ocorrendo.